### PR TITLE
feature/mult_objects: Add RenderableObjects

### DIFF
--- a/include/Material.hpp
+++ b/include/Material.hpp
@@ -1,3 +1,4 @@
+#pragma once
 #include "Shader.hpp"
 #include "Texture.hpp"
 #include <memory>

--- a/include/RenderableScene.hpp
+++ b/include/RenderableScene.hpp
@@ -1,0 +1,12 @@
+#include "Scene.hpp"
+#include <vector>
+#include "SceneObject.hpp"
+
+class RenderableScene : public Scene  {
+    protected:
+        std::vector<SceneObject> objects;
+
+    public:
+        virtual const std::vector<SceneObject>& get_objects() const { return objects; }
+        virtual void add_object(const SceneObject& obj) { objects.push_back(obj); }
+};

--- a/include/SceneObject.hpp
+++ b/include/SceneObject.hpp
@@ -1,0 +1,9 @@
+#pragma once
+#include "Mesh.hpp"
+#include "Material.hpp"
+
+struct SceneObject {
+    std::shared_ptr<Mesh> mesh;
+    std::shared_ptr<Material> material;
+    glm::mat4 transform;
+};

--- a/scenes/MainScene/MainScene.cpp
+++ b/scenes/MainScene/MainScene.cpp
@@ -3,6 +3,7 @@
 #include "Shader.hpp"
 #include "Mesh.hpp"
 #include "Renderer.hpp"
+#include "SceneObject.hpp"
 #include <GLFW/glfw3.h>
 
 void MainScene::initialize(){ 
@@ -53,29 +54,28 @@ void MainScene::initialize(){
         16,17,18,18,19,16,        // top
         20,21,22,22,23,20         // bottom
     };
-    quad_mesh = std::make_shared<Mesh>();
-    quad_mesh->init(vertices, sizeof(vertices), indices, sizeof(indices));
-
-    Light light1({1.0f, 5.0f, 2.0f}, {1.0f, 0.9f, 0.7f});
-    renderer->set_light(light1);
-
     auto shader = std::make_shared<Shader>("shaders/default.vert", "shaders/default.frag");
-    quad_material = std::make_shared<Material>(shader);
-}
+
+        for (int i = 0; i < 5; ++i) {
+            auto mesh = std::make_shared<Mesh>();
+            mesh->init(vertices, sizeof(vertices), indices, sizeof(indices));
+            
+            auto material = std::make_shared<Material>(shader);
+            glm::mat4 transform = glm::translate(glm::mat4(1.0f), glm::vec3(i * 2.0f, 0, 0));
+            
+            objects.push_back({mesh, material, transform});
+        }}
 
 void MainScene::update(float dt) { 
     rotation += rotation_speed * dt;
 }
 void MainScene::render() { 
-    if (camera && renderer && quad_mesh && quad_material) {
-        glm::mat4 model = glm::mat4(1.0f);
-        model = glm::scale(model, glm::vec3(scale));
-        model = glm::rotate(model, glm::radians(rotation), glm::vec3(0, 1, 0));
-        renderer->submit({ quad_mesh, quad_material, model });
+    for (auto& obj : objects) {
+        // Convert SceneObject into RenderCommand
+        renderer->submit({ obj.mesh, obj.material, obj.transform });
     }
-
     renderer->render_all(*camera, 1000, 1000);
-    renderer->clear();       
+    renderer->clear();
 }
 
 void MainScene::render_ui() {

--- a/scenes/MainScene/MainScene.hpp
+++ b/scenes/MainScene/MainScene.hpp
@@ -1,4 +1,4 @@
-#include "Scene.hpp"
+#include "RenderableScene.hpp"
 #include "imgui.h"
 #include <memory>
 
@@ -8,7 +8,7 @@ class Mesh;
 class Material;
 class PerspectiveCamera;
 
-class MainScene : public Scene {
+class MainScene : public RenderableScene {
     public:
         MainScene(Renderer* renderer, std::shared_ptr<Camera> camera)
             : renderer(renderer), camera(camera) {}
@@ -25,8 +25,6 @@ class MainScene : public Scene {
     private:
         Renderer* renderer;
         std::shared_ptr<Camera> camera;
-        std::shared_ptr<Mesh> quad_mesh;
-        std::shared_ptr<Material> quad_material;
 
         float rotation = 0.0f;
         float rotation_speed = 0.1f;


### PR DESCRIPTION
Refactored the scene architecture to support rendering multiple objects. Introduced a SceneObject structure containing mesh, material, and transform data, and replaced the single hardcoded cube with a dynamic list of scene objects. Updated the MainScene logic to iterate through and render each object individually. This improves flexibility and prepares the engine for future ray tracing integration.

resolves #14