### PR TITLE
feature/shader_switching: added shader switching to UI, shaders are c…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ set(MAIN_SOURCE_FILES
     ${SRC_DIR}/PerspectiveCamera.cpp
     ${SRC_DIR}/InputManager.cpp
     ${SRC_DIR}/ObjLoader.cpp
+    ${SRC_DIR}/ShaderLibrary.cpp
     ${SRC_DIR}/Ui.cpp
 
     # ImGui core

--- a/include/ShaderLibrary.hpp
+++ b/include/ShaderLibrary.hpp
@@ -1,0 +1,34 @@
+#pragma once
+#include <unordered_map>
+#include <string>
+#include <memory>
+#include <vector>
+#include <functional>
+#include "Shader.hpp"
+
+struct ShaderPtrHash {
+    std::size_t operator()(const std::shared_ptr<Shader>& s) const {
+        return std::hash<Shader*>()(s.get());
+    }
+};
+
+struct ShaderPtrEqual {
+    bool operator()(const std::shared_ptr<Shader>& lhs, const std::shared_ptr<Shader>& rhs) const {
+        return lhs.get() == rhs.get();
+    }
+};
+
+
+class Shader;
+
+class ShaderLibrary {
+    public:
+        static void load(const std::string& name, const std::string& vert_path, const std::string& frag_path);
+        static std::shared_ptr<Shader> get(const std::string& name);
+        static std::vector<std::string> get_keys();
+        static std::string get_name(const std::shared_ptr<Shader>& shader);
+
+    private:
+        static std::unordered_map<std::string, std::shared_ptr<Shader>> shaders;
+        static std::unordered_map<std::shared_ptr<Shader>, std::string, ShaderPtrHash, ShaderPtrEqual> reverse_lookup;
+};

--- a/scenes/MainScene/MainScene.cpp
+++ b/scenes/MainScene/MainScene.cpp
@@ -6,15 +6,19 @@
 #include "SceneObject.hpp"
 #include "ObjLoader.hpp"
 #include "Transform.hpp"
+#include "ShaderLibrary.hpp"
 #include <GLFW/glfw3.h>
 
 void MainScene::initialize(){ 
-    auto shader = std::make_shared<Shader>("shaders/default.vert", "shaders/default.frag");
+
+    ShaderLibrary::load("default", "shaders/default.vert", "shaders/default.frag");
+    ShaderLibrary::load("xyzmap", "shaders/default.vert", "shaders/xyzmap.frag");
+
 
     Light light1({1.0f, 10.0f, 5.0f}, {1.0f, 1.0f, 1.0f});
     renderer->set_light(light1);
     auto light_mesh = ObjLoader::load("models/Sphere.obj");
-    auto light_mat = std::make_shared<Material>(shader);
+    auto light_mat = std::make_shared<Material>(ShaderLibrary::get("default"));
 
     Transform light_transform;
     light_transform.position = light1.position;
@@ -24,7 +28,7 @@ void MainScene::initialize(){
 
 
     auto mesh = ObjLoader::load("models/Human.obj");            
-    auto material = std::make_shared<Material>(shader);
+    auto material = std::make_shared<Material>(ShaderLibrary::get("default"));
     Transform transform;
     transform.position = {0.0f, 0.0f, 0.0f};
     transform.cache_trigger = true;

--- a/shaders/xyzmap.frag
+++ b/shaders/xyzmap.frag
@@ -1,0 +1,20 @@
+#version 330 core
+
+in vec3 FragPos;
+in vec3 Normal;
+in vec3 Color;
+in vec2 TexCoord;
+
+out vec4 FragColor;
+
+uniform sampler2D uTexture;
+uniform vec3 lightPos;
+uniform vec3 viewPos;
+uniform vec3 lightColor;
+uniform bool use_texture;
+
+void main() {
+    vec3 norm = normalize(Normal);
+    FragColor = vec4(norm * 0.5 + 0.5, 1.0); // Encode -1..1 to 0..1
+}
+

--- a/src/ShaderLibrary.cpp
+++ b/src/ShaderLibrary.cpp
@@ -1,0 +1,37 @@
+#include "ShaderLibrary.hpp"
+
+std::unordered_map<std::string, std::shared_ptr<Shader>> ShaderLibrary::shaders;
+
+std::unordered_map<
+    std::shared_ptr<Shader>,
+    std::string,
+    ShaderPtrHash,
+    ShaderPtrEqual
+> ShaderLibrary::reverse_lookup;
+
+
+void ShaderLibrary::load(const std::string& name, const std::string& vert_path, const std::string& frag_path) {
+    auto shader = std::make_shared<Shader>(vert_path.c_str(), frag_path.c_str());
+    shaders[name] = shader;
+    reverse_lookup[shader] = name;
+}
+
+std::shared_ptr<Shader> ShaderLibrary::get(const std::string& name) {
+    return shaders.at(name);
+}
+
+std::vector<std::string> ShaderLibrary::get_keys() {
+    std::vector<std::string> keys;
+    for (const auto& pair : shaders) {
+        keys.push_back(pair.first);
+    }
+    return keys;
+}
+
+std::string ShaderLibrary::get_name(const std::shared_ptr<Shader>& shader) {
+    auto it = reverse_lookup.find(shader);
+    if (it != reverse_lookup.end()) {
+        return it->second;
+    }
+    return "<unknown>";
+}

--- a/src/Ui.cpp
+++ b/src/Ui.cpp
@@ -3,6 +3,7 @@
 #include "PerspectiveCamera.hpp"
 #include "SceneManager.hpp"
 #include "RenderableScene.hpp"
+#include "ShaderLibrary.hpp"
 #include <GLFW/glfw3.h>
 #include "Engine.hpp"
 
@@ -97,6 +98,22 @@ void UI::render() {
             changed |= ImGui::DragFloat3("Position", glm::value_ptr(obj.transform.position), 0.1f);
             changed |= ImGui::DragFloat3("Rotation", glm::value_ptr(obj.transform.rotation), 0.5f);
             changed |= ImGui::DragFloat3("Scale", glm::value_ptr(obj.transform.scale), 0.05f);
+
+            std::vector<std::string> shader_keys = ShaderLibrary::get_keys();
+            std::string current_shader_name = ShaderLibrary::get_name(obj.material->shader);
+
+            if (ImGui::BeginCombo("Shader", current_shader_name.c_str())) {
+                for (const auto& name : shader_keys) {
+                    bool selected = (current_shader_name == name);
+                    if (ImGui::Selectable(name.c_str(), selected)) {
+                        current_shader_name = name;
+                        obj.material->shader = ShaderLibrary::get(name);
+                    }
+                    if (selected)
+                        ImGui::SetItemDefaultFocus();
+                }
+                ImGui::EndCombo();
+            }
 
             if (changed) {
                 obj.transform.cache_trigger = true;


### PR DESCRIPTION

### 💡 PR: Add `ShaderLibrary` for Centralized Shader Management

This PR introduces a `ShaderLibrary` class to centralize and manage shader loading and retrieval across the engine. Key motivations and changes:

#### ✨ Features

* **Central Shader Registry**: Shaders are loaded once via `ShaderLibrary::load(name, vert, frag)` and accessed anywhere using `ShaderLibrary::get(name)`.
* **Reverse Lookup**: Enables getting the shader name from a `shared_ptr<Shader>` for UI/debugging purposes.
* **ImGui Integration**: Added a shader selector in the object inspector UI, allowing runtime material shader switching.
* **Scene Simplification**: Replaced direct shader allocations in `MainScene` with references from the library (`"default"`, `"xyzmap"`).

#### 🗂️ Files Added

* `ShaderLibrary.hpp` / `ShaderLibrary.cpp`
* `shaders/xyzmap.frag`: A debug fragment shader that encodes normals visually.

#### 🧠 Future Extensions

* Add runtime shader hot-reloading (e.g., file watching or manual reload).
* Optionally extend error handling for missing shader names in `get()`.