### PR TITLE
Feature/shader builder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,8 @@ add_custom_target(run
 
 
 file(COPY ${PROJECT_SOURCE_DIR}/shaders DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+file(COPY ${PROJECT_SOURCE_DIR}/textures DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+file(COPY ${PROJECT_SOURCE_DIR}/models DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 # Custom GDB run target
 add_custom_target(debug
   COMMAND gdb ${PROJECT_NAME}

--- a/include/Material.hpp
+++ b/include/Material.hpp
@@ -2,6 +2,10 @@
 #include "Shader.hpp"
 #include "Texture.hpp"
 #include <memory>
+#include <functional>
+
+class UniformContext;
+
 
 class Material {
     public:
@@ -9,4 +13,11 @@ class Material {
         void bind();
         std::shared_ptr<Shader> shader;
         std::shared_ptr<Texture> texture;
+        std::string sampler_name = "uTexture";
+        std::function<void(Shader& shader, const UniformContext& ctx)> bind_uniforms;
+        
+        void apply_uniforms(const UniformContext& ctx) {
+            shader->activate_shader();
+            if(bind_uniforms) bind_uniforms(*shader, ctx);
+        }
 };

--- a/include/Mesh.hpp
+++ b/include/Mesh.hpp
@@ -58,7 +58,7 @@ template<>
 
 class Mesh {
     public:
-        Mesh() = default;
+        Mesh();
         ~Mesh();
 
 

--- a/include/Renderer.hpp
+++ b/include/Renderer.hpp
@@ -38,9 +38,7 @@ private:
 
     // --- Sky Box ---
     std::shared_ptr<Mesh> skybox_mesh;
-    std::shared_ptr<Texture> skybox_texture;
-    std::shared_ptr<Shader> skybox_shader;
-
+    std::shared_ptr<Material> skybox_material;
     // --- Grid Mesh ---
     std::unique_ptr<VBO> grid_vbo;
     VAO grid_vao;

--- a/include/UniformContext.hpp
+++ b/include/UniformContext.hpp
@@ -1,0 +1,11 @@
+#pragma once
+#include <glm/glm.hpp>
+
+struct UniformContext {
+    glm::mat4 view;
+    glm::mat4 projection;
+    glm::vec3 view_pos;
+    glm::vec3 light_pos;
+    glm::vec3 light_color;
+    glm::mat4 model;
+};

--- a/include/UniformPresets.hpp
+++ b/include/UniformPresets.hpp
@@ -17,6 +17,11 @@ namespace UniformPresets {
         shader.set_vec3("lightColor", ctx.light_color);
     };
 
+    inline auto normal_debug_bind = [](Shader& shader, const UniformContext& ctx) {
+        shader.set_mat4("model", ctx.model);
+        shader.set_mat4("view", ctx.view);
+        shader.set_mat4("projection", ctx.projection);
+    };
 
     inline auto skybox_bind = [](Shader& shader, const UniformContext& ctx) {
         glm::mat4 view_no_translation = glm::mat4(glm::mat3(ctx.view));

--- a/include/UniformPresets.hpp
+++ b/include/UniformPresets.hpp
@@ -1,0 +1,27 @@
+#include "Shader.hpp"
+#include "UniformContext.hpp"
+
+namespace UniformPresets {
+    inline auto basic_bind = [](Shader& shader, const UniformContext& ctx) {
+        shader.set_mat4("model", ctx.model);
+        shader.set_mat4("view", ctx.view);
+        shader.set_mat4("projection", ctx.projection);
+    };
+
+    inline auto full_lighting_bind = [](Shader& shader, const UniformContext& ctx) {
+        shader.set_mat4("model", ctx.model);
+        shader.set_mat4("view", ctx.view);
+        shader.set_mat4("projection", ctx.projection);
+        shader.set_vec3("lightPos", ctx.light_pos);
+        shader.set_vec3("viewPos", ctx.view_pos);
+        shader.set_vec3("lightColor", ctx.light_color);
+    };
+
+
+    inline auto skybox_bind = [](Shader& shader, const UniformContext& ctx) {
+        glm::mat4 view_no_translation = glm::mat4(glm::mat3(ctx.view));
+        shader.set_mat4("view", view_no_translation);
+        shader.set_mat4("projection", ctx.projection);
+    };
+
+}

--- a/scenes/MainScene/MainScene.cpp
+++ b/scenes/MainScene/MainScene.cpp
@@ -66,6 +66,18 @@ void MainScene::initialize(){
 
 void MainScene::update(float dt) { 
     rotation += rotation_speed * dt;
+
+    // --- Crude lighting update fix
+    for (auto& obj : objects) {
+    if (obj.name == "light1") {
+        renderer->set_light(Light{
+            obj.transform.position,
+            renderer->get_light().color // keep previous color
+        });
+    }
+}
+
+
 }
 void MainScene::render() { 
     for (auto& obj : objects) {

--- a/scenes/MainScene/MainScene.cpp
+++ b/scenes/MainScene/MainScene.cpp
@@ -35,7 +35,7 @@ void MainScene::initialize(){
     default_material->bind_uniforms = default_bind;
 
     auto xyz_material = std::make_shared<Material>(ShaderLibrary::get("xyzmap"));
-    xyz_material->bind_uniforms = UniformPresets::basic_bind; 
+    xyz_material->bind_uniforms = UniformPresets::normal_debug_bind; 
 
     auto basic_material = std::make_shared<Material>(ShaderLibrary::get("basic"));
     basic_material->bind_uniforms = UniformPresets::basic_bind; 

--- a/shaders/basic.frag
+++ b/shaders/basic.frag
@@ -1,0 +1,7 @@
+#version 330 core
+out vec4 FragColor;
+
+void main() {
+    FragColor = vec4(0.8, 0.8, 0.8, 1.0); // default gray
+}
+

--- a/shaders/basic.vert
+++ b/shaders/basic.vert
@@ -1,0 +1,11 @@
+#version 330 core
+layout (location = 0) in vec3 aPos;
+
+uniform mat4 model;
+uniform mat4 view;
+uniform mat4 projection;
+
+void main() {
+    gl_Position = projection * view * model * vec4(aPos, 1.0);
+}
+

--- a/shaders/default.frag
+++ b/shaders/default.frag
@@ -15,28 +15,22 @@ uniform bool selected;
 uniform bool use_texture;
 
 void main() {
-    // Ambient
-    float ambientStrength = 0.2;
-    vec3 ambient = ambientStrength * lightColor;
-
-    // Diffuse
     vec3 norm = normalize(Normal);
     vec3 lightDir = normalize(lightPos - FragPos);
     float diff = max(dot(norm, lightDir), 0.0);
     vec3 diffuse = diff * lightColor;
+    vec3 baseColor = Color;
 
-    // Texture color
-    vec3 texColor = texture(uTexture, TexCoord).rgb;
-
-    // Final color logic
-    vec3 baseColor = Color * texColor;
-
-    // Override with highlight color if selected
-    if (selected) {
-        baseColor = mix(baseColor, vec3(0.6, 0.6, 0.6), 0.6);
+    if (use_texture) {
+        vec3 texColor = texture(uTexture, TexCoord).rgb;
+        baseColor *= texColor;
     }
 
-    vec3 result = (ambient + diffuse) * baseColor;
-    FragColor = vec4(result, 1.0);
+    if (selected) {
+        baseColor = mix(baseColor, vec3(1.0, 1.0, 0.0), 0.5); // yellow highlight
+    }
+
+    FragColor = vec4((0.2 + diffuse) * baseColor, 1.0);
 }
+
 

--- a/shaders/xyzmap.frag
+++ b/shaders/xyzmap.frag
@@ -1,7 +1,10 @@
 #version 330 core
+
+in vec3 Normal;
 out vec4 FragColor;
 
 void main() {
-    FragColor = vec4(1.0, 0.0, 1.0, 1.0); // Magenta for visibility
+    vec3 norm = normalize(Normal);
+    FragColor = vec4(norm * 0.5 + 0.5, 1.0); // Map [-1, 1] to [0, 1]
 }
 

--- a/shaders/xyzmap.frag
+++ b/shaders/xyzmap.frag
@@ -1,20 +1,7 @@
 #version 330 core
-
-in vec3 FragPos;
-in vec3 Normal;
-in vec3 Color;
-in vec2 TexCoord;
-
 out vec4 FragColor;
 
-uniform sampler2D uTexture;
-uniform vec3 lightPos;
-uniform vec3 viewPos;
-uniform vec3 lightColor;
-uniform bool use_texture;
-
 void main() {
-    vec3 norm = normalize(Normal);
-    FragColor = vec4(norm * 0.5 + 0.5, 1.0); // Encode -1..1 to 0..1
+    FragColor = vec4(1.0, 0.0, 1.0, 1.0); // Magenta for visibility
 }
 

--- a/shaders/xyzmap.vert
+++ b/shaders/xyzmap.vert
@@ -1,0 +1,11 @@
+#version 330 core
+layout (location = 0) in vec3 aPos;
+
+uniform mat4 model;
+uniform mat4 view;
+uniform mat4 projection;
+
+void main() {
+    gl_Position = projection * view * model * vec4(aPos, 1.0);
+}
+

--- a/shaders/xyzmap.vert
+++ b/shaders/xyzmap.vert
@@ -1,11 +1,18 @@
 #version 330 core
+
 layout (location = 0) in vec3 aPos;
+layout (location = 1) in vec3 aNormal;
+
+out vec3 Normal;
 
 uniform mat4 model;
 uniform mat4 view;
 uniform mat4 projection;
 
 void main() {
+    mat3 normalMatrix = transpose(inverse(mat3(model)));
+    Normal = normalMatrix * aNormal;
+
     gl_Position = projection * view * model * vec4(aPos, 1.0);
 }
 

--- a/src/Material.cpp
+++ b/src/Material.cpp
@@ -9,13 +9,13 @@ Material::Material(std::shared_ptr<Shader> shader, std::shared_ptr<Texture> text
 
 void Material::bind() {
     shader->activate_shader();
-    // here we can set other uniforms like use_texture
-    // --- use_texture ---
-    shader->activate_shader();
+
     if (texture) {
         shader->set_bool("use_texture", true);
-        texture->bind();
+        texture->tex_unit(*shader, sampler_name.c_str(), 0); // Binds sampler2D to unit 0
+        texture->bind(); // Binds the actual texture to GL_TEXTURE0
     } else {
         shader->set_bool("use_texture", false);
     }
 }
+

--- a/src/Material.cpp
+++ b/src/Material.cpp
@@ -9,11 +9,12 @@ Material::Material(std::shared_ptr<Shader> shader, std::shared_ptr<Texture> text
 
 void Material::bind() {
     shader->activate_shader();
-
     if (texture) {
         shader->set_bool("use_texture", true);
-        texture->tex_unit(*shader, sampler_name.c_str(), 0); // Binds sampler2D to unit 0
-        texture->bind(); // Binds the actual texture to GL_TEXTURE0
+        texture->bind();
+        if (!sampler_name.empty()) {
+            texture->tex_unit(*shader, sampler_name.c_str(), 0); // default unit 0
+        }
     } else {
         shader->set_bool("use_texture", false);
     }

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -6,6 +6,8 @@
 #include "Camera.hpp"
 #include "Mesh.hpp"
 #include "Material.hpp"
+#include "UniformContext.hpp"
+#include "UniformPresets.hpp"
 
 
 Renderer::Renderer() {}
@@ -17,44 +19,40 @@ void Renderer::submit(const RenderCommand& render_cmd) {
 }
 
 void Renderer::render_all(const Camera& camera, int screen_width, int screen_height) {
+    UniformContext ctx;
     // View and projection matrices
-    glm::mat4 view = camera.get_view_matrix();
-    glm::mat4 projection = camera.get_projection_matrix();
+    ctx.view = camera.get_view_matrix();
+    ctx.view_pos = camera.get_position();
+    ctx.projection = camera.get_projection_matrix();
 
     // Light properties (temporary static light)
-    glm::vec3 light_pos(2.0f, 2.0f, 2.0f);
-    glm::vec3 light_color(1.0f, 1.0f, 1.0f);
-    glm::vec3 view_pos = camera.get_position();
+    ctx.light_pos = light.position;
+    ctx.light_color = light.color;
 
     for (const auto& cmd : render_queue) {
-        auto shader = cmd.material->shader;
-
+        auto& material = *cmd.material;
+        auto shader = material.shader;
         shader->activate_shader();
 
-        // Set per-frame uniforms
-        shader->set_mat4("view", view);
-        shader->set_mat4("projection", projection);
-        shader->set_vec3("lightPos", light.position);
-        shader->set_vec3("lightColor", light.color);
-        shader->set_vec3("viewPos", view_pos);
+        ctx.model = cmd.transform.model_matrix;
 
-        // Set per-object uniforms
-        shader->set_mat4("model", cmd.transform.model_matrix);
+        if (material.bind_uniforms) {
+            material.bind_uniforms(*shader, ctx);
+        }
 
-        cmd.material->bind(); // binds texture and such
+        material.bind(); // binds textures, etc.
         cmd.mesh->draw();
     }
-
     render_queue.clear(); // empty for next frame
 }
 
 void Renderer::init_skybox(const std::vector<std::string>& faces, std::shared_ptr<Shader> shader) {
-    skybox_shader = shader;
-    skybox_texture = std::make_shared<Texture>(faces, GL_TEXTURE0);
+    skybox_material = std::make_shared<Material>(shader, std::make_shared<Texture>(faces, GL_TEXTURE0));
+    skybox_material->sampler_name = "skybox";
+    skybox_material->bind_uniforms = UniformPresets::skybox_bind; 
 
     skybox_mesh = std::make_shared<Mesh>();
     skybox_mesh->init_positions_only(skybox_vertices, sizeof(skybox_vertices));
-
     skybox_mesh->set_vertex_cnt(36);
     skybox_mesh->set_draw_mode(MeshDrawMode::Arrays);
 
@@ -85,27 +83,23 @@ void Renderer::init_grid(std::shared_ptr<Shader> shader, float size, float step)
 
 
 void Renderer::render_skybox(const Camera& camera, int screen_width, int screen_height) {
-    if (!skybox_enabled || !skybox_shader || !skybox_texture || !skybox_mesh) {
+    if (!skybox_enabled || !skybox_material || !skybox_mesh) {
         return;
     }
 
-    // Change depth function so skybox is drawn behind all other objects
     glDepthFunc(GL_LEQUAL);
 
-    skybox_shader->activate_shader();
+    UniformContext ctx;
+    ctx.view = camera.get_view_matrix();
+    ctx.projection = camera.get_projection_matrix();
 
-    // Remove camera translation from view matrix
-    glm::mat4 view = glm::mat4(glm::mat3(camera.get_view_matrix()));
-    glm::mat4 projection = camera.get_projection_matrix();
+    skybox_material->shader->activate_shader();
+    if (skybox_material->bind_uniforms)
+        skybox_material->bind_uniforms(*skybox_material->shader, ctx);
 
-    skybox_shader->set_mat4("view", view);
-    skybox_shader->set_mat4("projection", projection);
-    skybox_texture->tex_unit(*skybox_shader, "skybox", 0); // Bind to texture unit 0
-    skybox_texture->bind();
+    skybox_material->bind();
+    skybox_mesh->draw();
 
-    skybox_mesh->draw(); // Only positions, no EBO
-
-    // Reset depth function
     glDepthFunc(GL_LESS);
 }
 


### PR DESCRIPTION
This PR introduces a more flexible material and uniform handling system for rendering, along with several improvements and additions across shaders, mesh drawing, and scene setup:

### ✨ **Core Additions**

* **`UniformContext` & `UniformPresets`**:

  * Added `UniformContext` struct to encapsulate view, projection, lighting, and model data.
  * Introduced `UniformPresets` with reusable lambdas for binding common shader uniforms.

* **Material Enhancements**:

  * `Material` now supports `bind_uniforms` as a customizable lambda.
  * Added `apply_uniforms()` method to invoke uniform logic cleanly.
  * Added `sampler_name` to control texture uniform binding.

* **Skybox Refactor**:

  * Replaced separate shader and texture with a single `skybox_material` abstraction.
  * Skybox rendering now uses `UniformPresets::skybox_bind`.

### 🧱 **Infrastructure Changes**

* `CMakeLists.txt` now copies `textures/` and `models/` directories.
* New shaders:

  * `basic.vert` / `basic.frag` – Simple gray shader.
  * `xyzmap.vert` / `xyzmap.frag` – Normal visualization shader.

### 🧠 **Scene Improvements**

* Updated `MainScene` to use the new material system and shader presets.
* Dynamically updates lighting based on the transform of `light1`.

### 🧰 **Mesh and Renderer Improvements**

* Better safety checks in `Mesh::draw()` (e.g., VBO/EBO existence, draw mode handling).
* Debug output for `index_cnt` in `Mesh::init`.
* Default `draw_mode` set to `Indexed`.
* `Renderer::render_all()` now uses `UniformContext` and defers all uniform logic to materials.

### 🎨 **Shader Logic Refinement**

* Simplified and clarified lighting logic in `default.frag`.
* Removed unused uniforms from `xyzmap` shader.
