### PR TITLE
feature/mirror_shader: added reflect object inside SecondScene

### DIFF
--- a/include/Mesh.hpp
+++ b/include/Mesh.hpp
@@ -70,6 +70,7 @@ class Mesh {
         void set_draw_mode(MeshDrawMode mode) { draw_mode = mode; }
         void init(const float* vertices, size_t v_size, const unsigned int* indices, size_t i_size);
         void init_positions_only(const float* vertices, size_t v_size);
+        static std::unique_ptr<Mesh> create_uv_sphere(int segments, int rings, float radius = 1.0f);
         void draw() const;
 
         // Getters

--- a/include/Renderer.hpp
+++ b/include/Renderer.hpp
@@ -29,6 +29,7 @@ public:
 
     void set_light(const Light& light);
     Light get_light() { return light; }
+    std::shared_ptr<Material> get_skybox_material() { return skybox_material; }
     bool skybox_enabled = false;
     bool grid_enabled = true;
 

--- a/shaders/reflect.frag
+++ b/shaders/reflect.frag
@@ -1,0 +1,15 @@
+#version 330 core
+out vec4 FragColor;
+
+in vec3 WorldPos;
+in vec3 Normal;
+
+uniform samplerCube skybox;
+uniform vec3 viewPos;
+
+void main()
+{
+    vec3 I = normalize(WorldPos - viewPos);
+    vec3 R = reflect(I, normalize(Normal));
+    FragColor = texture(skybox, R);
+}

--- a/shaders/reflect.vert
+++ b/shaders/reflect.vert
@@ -1,0 +1,19 @@
+#version 330 core
+layout (location = 0) in vec3 aPos;
+layout (location = 1) in vec3 aNormal;
+
+out vec3 WorldPos;
+out vec3 Normal;
+
+uniform mat4 model;
+uniform mat4 view;
+uniform mat4 projection;
+
+void main()
+{
+    vec4 worldPosition = model * vec4(aPos, 1.0);
+    WorldPos = worldPosition.xyz;
+    Normal = mat3(transpose(inverse(model))) * aNormal;
+    gl_Position = projection * view * worldPosition;
+}
+

--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -73,6 +73,7 @@ bool Engine::init() {
     glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
     glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
     glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+    glfwWindowHint(GLFW_SAMPLES, 4);
 
     window = glfwCreateWindow(SCREEN_WIDTH, SCREEN_HEIGHT, "3D Space", nullptr, nullptr);
     if (!window) {

--- a/src/Shader.cpp
+++ b/src/Shader.cpp
@@ -36,8 +36,11 @@ std::string preprocess_shader(const std::string& path) {
             result << line << '\n';
         }
     }
+    std::string result_str = result.str();
+    LOG_DEBUG("Preprocessed shader [" + path + "]:\n" + result_str);
+    return result_str;
 
-    return result.str();
+
 }
 
 


### PR DESCRIPTION
### ✨ Feature: Reflective UV Sphere with Skybox Reflection Shader

This PR introduces a reflective UV sphere using a custom shader and integrates it into the rendering pipeline with support for environment reflections via the skybox.

---

### 🔧 Changes Summary

#### 🎨 Scene & Rendering

* **`SecondScene.cpp`**

  * Replaces the hardcoded pyramid mesh with a dynamically generated UV sphere (`Mesh::create_uv_sphere()`).
  * Introduces a new reflective material using a shader pair (`reflect.vert` and `reflect.frag`).
  * Material samples from the skybox for dynamic reflections.
  * Scene rendering now iterates over a list of objects, each submitted with an ID.

* **`Renderer.hpp`**

  * Added `get_skybox_material()` to allow materials to sample from the active skybox.

#### 🧠 Mesh Generation

* **`Mesh.cpp / Mesh.hpp`**

  * Adds static method `create_uv_sphere(int segments, int rings, float radius)` for procedural mesh generation.
  * Uses proper vertex normal calculation and UV mapping for correct shading and sampling.

#### 🖼️ Shaders

* **`reflect.vert`**

  * Computes world-space position and transformed normals.
* **`reflect.frag`**

  * Uses reflection vector and samples from a cubemap (skybox) to simulate environment reflection.

#### 🧪 Engine Enhancements

* **`Engine.cpp`**

  * Enables 4x MSAA via `glfwWindowHint(GLFW_SAMPLES, 4)` for improved visual quality.

#### 🛠 Debug & Logging

* **`Shader.cpp`**

  * Adds debug logging of preprocessed shader sources.
