### PR TITLE
Decouple GL pipeline state from Mesh::draw();

### DIFF
--- a/include/cosmos/render/Renderer.hpp
+++ b/include/cosmos/render/Renderer.hpp
@@ -15,6 +15,7 @@
 // ==
 #include <cosmos/render/VAO.hpp>
 #include <cosmos/scene/Light.hpp>
+#include <cosmos/render/gfx/GLStateCache.hpp>
 
 // ==
 // Forward Declare
@@ -49,6 +50,7 @@ public:
 
 private:
     std::vector<RenderCommand> render_queue;
+    gfx::GLStateCache state_cache_;
     std::shared_ptr<ui::UI> ui = nullptr;
     scene::Light light = scene::Light({2.0f, 2.0f, 2.0f}, {1.0f, 1.0f, 1.0f});
 

--- a/include/cosmos/render/gfx/GLStateCache.hpp
+++ b/include/cosmos/render/gfx/GLStateCache.hpp
@@ -1,0 +1,25 @@
+#pragma once
+// ==
+// Standard Library
+// ==
+
+// ==
+// Third Party
+// ==
+
+// ==
+// Cosmos
+// ==
+#include <cosmos/render/gfx/RenderState.hpp>
+
+namespace cosmos::render::gfx {
+
+class GLStateCache {
+public:
+    void apply(const RenderState& s);
+
+private:
+    RenderState cached_{};
+    void set_cap(GLenum cap, bool enable, bool& flag);
+};
+}

--- a/include/cosmos/render/gfx/RenderCommand.hpp
+++ b/include/cosmos/render/gfx/RenderCommand.hpp
@@ -13,6 +13,7 @@
 // Cosmos
 // ==
 #include <cosmos/render/Transform.hpp>
+#include <cosmos/render/gfx/RenderState.hpp>
 
 // ==
 // Forward Declare
@@ -27,6 +28,7 @@ public:
     std::shared_ptr<Material> material;
     Transform transform;
     int object_id;
+    gfx::RenderState state = gfx::RenderState::Opaque();
 };
 
 }

--- a/include/cosmos/render/gfx/RenderState.hpp
+++ b/include/cosmos/render/gfx/RenderState.hpp
@@ -1,0 +1,39 @@
+#pragma once
+// ==
+// Standard Library
+// ==
+
+// ==
+// Third Party
+// ==
+#include <glad/glad.h>
+
+// ==
+// Cosmos
+// ==
+
+namespace cosmos::render::gfx {
+
+struct BlendFunc { GLenum src = GL_SRC_ALPHA, dst = GL_ONE_MINUS_SRC_ALPHA; };
+
+struct RenderState {
+    bool blending = false;
+    bool depth_test = true;
+    bool depth_write = true;
+    bool cull_face = true;
+    GLenum cull_mode = GL_BACK;
+    GLenum depth_func = GL_LESS;
+    BlendFunc blend{};
+
+    static RenderState Opaque() {
+        RenderState s; /* defaults are fine */ return s;
+    }
+    static RenderState Transparent() {
+        RenderState s;
+        s.blending = true;
+        s.depth_write = false;
+        s.blend = { GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA };
+        return s;
+    }
+};
+}

--- a/scenes/MainScene/MainScene.cpp
+++ b/scenes/MainScene/MainScene.cpp
@@ -7,7 +7,7 @@
 #include <cosmos/render/Material.hpp>
 #include <cosmos/render/UniformContext.hpp>
 #include <cosmos/render/UniformPresets.hpp>
-#include <cosmos/render/RenderCommand.hpp>
+#include <cosmos/render/gfx/RenderCommand.hpp>
 #include <cosmos/render/VertexLayouts.hpp>
 #include <cosmos/assets/ShaderLibrary.hpp>
 #include <cosmos/assets/SkyboxUtils.hpp>

--- a/scenes/SecondScene/SecondScene.cpp
+++ b/scenes/SecondScene/SecondScene.cpp
@@ -18,7 +18,7 @@
 #include <cosmos/render/Texture.hpp>
 #include <cosmos/render/PBRMaterial.hpp>
 #include <cosmos/render/UniformContext.hpp>
-#include <cosmos/render/RenderCommand.hpp>
+#include <cosmos/render/gfx/RenderCommand.hpp>
 #include <cosmos/assets/ShaderLibrary.hpp>
 #include <cosmos/assets/MaterialLibrary.hpp>
 #include <cosmos/assets/SkyboxUtils.hpp>

--- a/src/render/Mesh.cpp
+++ b/src/render/Mesh.cpp
@@ -53,10 +53,7 @@ void Mesh::init_positions_only(const float* vertices, size_t v_size) {
 }
 
 
-void Mesh::draw(const VertexLayoutView& layout) const {
-    glEnable(GL_BLEND);
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-
+void Mesh::draw(const VertexLayoutView& layout) const { 
     if (!vbo) { LOG_ERROR("[Mesh::draw] VBO not initialized"); return; }
 
     const VAO& vao = vao_for(layout);

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -17,7 +17,7 @@
 #include <cosmos/render/Material.hpp>
 #include <cosmos/render/UniformContext.hpp>
 #include <cosmos/render/UniformPresets.hpp>
-#include <cosmos/render/RenderCommand.hpp>
+#include <cosmos/render/gfx/RenderCommand.hpp>
 #include <cosmos/assets/Skybox.hpp>
 #include <cosmos/scene/Camera.hpp>
 #include <cosmos/ui/Ui.hpp>
@@ -50,6 +50,11 @@ void Renderer::render_all(const scene::Camera& camera, int screen_width, int scr
     };
 
     for (const auto& cmd : render_queue) {
+
+        // --- Apply pipeline state for this draw (once per pass)
+        state_cache_.apply(cmd.state);
+
+
         auto& material = *cmd.material;
         auto shader = material.shader;
         shader->activate_shader();

--- a/src/render/gfx/GLStateCache.cpp
+++ b/src/render/gfx/GLStateCache.cpp
@@ -1,0 +1,40 @@
+// ==
+// Standard Library
+// ==
+
+// ==
+// Third Party
+// ==
+#include <glad/glad.h>
+
+// ==
+// Cosmos
+// ==
+#include <cosmos/render/gfx/GLStateCache.hpp>
+
+namespace cosmos::render::gfx {
+
+void GLStateCache::set_cap(GLenum cap, bool enable, bool& flag) {
+    if(flag != enable) { (enable ? glEnable : glDisable)(cap); flag = enable; }
+}
+
+void GLStateCache::apply(const RenderState& s) {
+    set_cap(GL_BLEND, s.blending, cached_.blending);
+    set_cap(GL_DEPTH_TEST, s.depth_test, cached_.depth_test);
+    set_cap(GL_CULL_FACE, s.cull_face, cached_.cull_face);
+
+    if(s.cull_face && cached_.cull_mode != s.cull_mode) {
+        glCullFace(s.cull_mode); cached_.cull_mode = s.cull_mode;
+    }
+
+    if(cached_.depth_func != s.depth_func) {
+        glDepthFunc(s.depth_func); cached_.depth_func = s.depth_func;
+    }
+
+    if(s.blending &&
+       (cached_.blend.src != s.blend.src || cached_.blend.dst != s.blend.dst)) {
+        glBlendFunc(s.blend.src, s.blend.dst); cached_.blend = s.blend;
+    }
+}
+
+}


### PR DESCRIPTION
## PR: Introduce `RenderState` + `GLStateCache`, move state out of `Mesh::draw()`

### New implementations

* **`gfx::RenderState`** (`include/cosmos/render/gfx/RenderState.hpp`)
  Holds blending, depth, and culling settings. Includes helpers:

  ```cpp
  static RenderState Opaque();
  static RenderState Transparent();
  ```
* **`gfx::GLStateCache`** (`include/cosmos/render/gfx/GLStateCache.hpp/.cpp`)
  Applies a `RenderState` while caching previous values to avoid redundant GL calls.
* **Moved `RenderCommand`** under `render/gfx/` and added a `RenderState` member:

  ```cpp
  gfx::RenderState state = gfx::RenderState::Opaque();
  ```

### Important changes

* **Mesh no longer sets GL state**

* glEnable(GL\_BLEND);

* glBlendFunc(GL\_SRC\_ALPHA, GL\_ONE\_MINUS\_SRC\_ALPHA);

  ```
  Now only binds VAO and draws.

  ```

* **Renderer applies state per command**

  ```cpp
  for (const auto& cmd : render_queue) {
      state_cache_.apply(cmd.state);   // new
      auto& material = *cmd.material;
      ...
      cmd.mesh->draw(material.vertex_layout());
  }
  ```

* **Renderer owns a cache**

  ```cpp
  gfx::GLStateCache state_cache_;
  ```

### Summary

* `Mesh::draw()` is now geometry-only.
* `Renderer` decides pipeline state using `RenderCommand.state`.
* Transparent/opaque behavior is explicit with `RenderState::Transparent()` or `RenderState::Opaque()`.
