### PR TITLE
feature/71: added AlphaModes and transparent/opaque passes

### DIFF
--- a/include/cosmos/render/Material.hpp
+++ b/include/cosmos/render/Material.hpp
@@ -15,6 +15,7 @@
 // ==
 #include <cosmos/render/Shader.hpp>
 #include <cosmos/render/VertexLayouts.hpp>
+#include <cosmos/render/gfx/RenderState.hpp>
 
 // ==
 // Forward Declare
@@ -22,6 +23,15 @@
 namespace cosmos::render { class UniformContext; class Texture; }
 
 namespace cosmos::render {
+
+
+
+enum AlphaMode {
+    Opaque,
+    Mask,
+    Blend 
+};
+
 class Material {
 public:
     Material(std::shared_ptr<Shader> shader,
@@ -47,6 +57,11 @@ public:
         shader->activate_shader();
         if(bind_uniforms) bind_uniforms(*shader, ctx);
     }
+
+    gfx::RenderState default_state = gfx::RenderState::Opaque();
+    AlphaMode alpha_mode = AlphaMode::Opaque;
+    float opacity = 0.1;
+    float alpha_cutoff;
 
 private:
     VertexLayoutDesc layout_;   // points to a static layout singleton

--- a/include/cosmos/render/gfx/RenderCommand.hpp
+++ b/include/cosmos/render/gfx/RenderCommand.hpp
@@ -29,6 +29,8 @@ public:
     Transform transform;
     int object_id;
     gfx::RenderState state = gfx::RenderState::Opaque();
+    float depth = 0.0f;
+    bool transparent = false;
 };
 
 }

--- a/include/cosmos/render/gfx/RenderState.hpp
+++ b/include/cosmos/render/gfx/RenderState.hpp
@@ -23,7 +23,7 @@ struct RenderState {
     bool cull_face = true;
     GLenum cull_mode = GL_BACK;
     GLenum depth_func = GL_LESS;
-    BlendFunc blend{};
+    BlendFunc blend{GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA};
 
     static RenderState Opaque() {
         RenderState s; /* defaults are fine */ return s;

--- a/shaders/default.frag
+++ b/shaders/default.frag
@@ -12,6 +12,7 @@ uniform vec3 lightPos;
 uniform vec3 viewPos;
 uniform vec3 lightColor;
 uniform bool use_texture;
+uniform float uAlpha;
 
 void main() {
     vec3 norm = normalize(Normal);
@@ -26,7 +27,7 @@ void main() {
     }
 
 
-    FragColor = vec4((0.2 + diffuse) * baseColor, 1.0);
+    FragColor = vec4((0.2 + diffuse) * baseColor, uAlpha);
 }
 
 

--- a/src/render/gfx/GLStateCache.cpp
+++ b/src/render/gfx/GLStateCache.cpp
@@ -18,23 +18,43 @@ void GLStateCache::set_cap(GLenum cap, bool enable, bool& flag) {
     if(flag != enable) { (enable ? glEnable : glDisable)(cap); flag = enable; }
 }
 
+// GLStateCache.cpp
 void GLStateCache::apply(const RenderState& s) {
-    set_cap(GL_BLEND, s.blending, cached_.blending);
     set_cap(GL_DEPTH_TEST, s.depth_test, cached_.depth_test);
-    set_cap(GL_CULL_FACE, s.cull_face, cached_.cull_face);
+    set_cap(GL_CULL_FACE,  s.cull_face,  cached_.cull_face);
 
-    if(s.cull_face && cached_.cull_mode != s.cull_mode) {
+    if (cached_.depth_write != s.depth_write) {
+        glDepthMask(s.depth_write ? GL_TRUE : GL_FALSE);
+        cached_.depth_write = s.depth_write;
+    }
+    if (s.cull_face && cached_.cull_mode != s.cull_mode) {
         glCullFace(s.cull_mode); cached_.cull_mode = s.cull_mode;
     }
-
-    if(cached_.depth_func != s.depth_func) {
+    if (cached_.depth_func != s.depth_func) {
         glDepthFunc(s.depth_func); cached_.depth_func = s.depth_func;
     }
 
-    if(s.blending &&
-       (cached_.blend.src != s.blend.src || cached_.blend.dst != s.blend.dst)) {
-        glBlendFunc(s.blend.src, s.blend.dst); cached_.blend = s.blend;
+    // --- Handle blending explicitly (mirrors your manual fix) ---
+    bool just_enabled = false;
+    if (s.blending) {
+        if (!cached_.blending) {
+            glEnable(GL_BLEND);
+            cached_.blending = true;
+            just_enabled = true;
+        }
+        // Always ensure func is correct when blending is ON,
+        // and especially right after enabling.
+        if (just_enabled ||
+            cached_.blend.src != s.blend.src ||
+            cached_.blend.dst != s.blend.dst) {
+            glBlendFunc(s.blend.src, s.blend.dst);
+            cached_.blend = s.blend;
+        }
+    } else {
+        if (cached_.blending) {
+            glDisable(GL_BLEND);
+            cached_.blending = false;
+        }
     }
 }
-
 }


### PR DESCRIPTION
### PR: Introduce Alpha Modes and Transparent Rendering Passes

#### Summary

This PR refactors the rendering pipeline to properly support **opaque, mask, and blend alpha modes**, and separates draw calls into opaque and transparent passes with correct state handling. It also extends `GLStateCache` to robustly manage blending and depth write state.

#### Changes

* **Material**

  * Added `AlphaMode` enum (`Opaque`, `Mask`, `Blend`).
  * Added `default_state`, `alpha_mode`, `opacity`, and `alpha_cutoff` fields.
  * Materials can now define their intended alpha behavior and default GL state.
* **RenderCommand**

  * Added `depth` (camera-space distance for sorting).
  * Added `transparent` flag (set during submit).
* **RenderState**

  * Default `blend` now initialized to `(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)`.
  * Added convenience constructors (`Opaque()`, `Transparent()`).
* **MainScene**

  * Submits objects via `RenderCommand` with `state` from `material->default_state`.
  * Sets `cmd.transparent` based on `alpha_mode`, blending state, or opacity.
  * Skybox is rendered before main scene objects.
* **Renderer**

  * Reworked `render_all`:

    * Builds a per-frame uniform context.
    * Partitions render commands into opaque/transparent lists.
    * Sorts opaque by pipeline (shader/material/mesh).
    * Sorts transparent back-to-front by depth.
    * Runs two passes: opaque (depth write ON, blending OFF) then transparent (depth write OFF, blending ON).
  * Explicitly restores depth mask around skybox rendering.
* **GLStateCache**

  * Removed generic `set_cap` for blending.
  * Explicit handling for blending: ensures `glBlendFunc` is always set correctly on first enable or when src/dst changes.
  * Manages depth write state with `glDepthMask`.

#### Why

* Correct handling of transparency requires separating opaque and transparent passes:

  * **Opaque:** depth write ON, blending OFF.
  * **Mask:** depth write ON, blending OFF + discard in shader.
  * **Blend:** depth write OFF, blending ON, sorted back-to-front.
* Previous implementation defaulted everything to “blend,” which caused artifacts and incorrect depth handling.
* State cache previously missed setting `glBlendFunc` on first enable, leading to opaque rendering even when alpha < 1.0. Fixed by explicit blending logic.

#### Impact

* Materials can now be authored with clear alpha semantics.
* Transparent objects render correctly with blending and depth order.
* Skybox rendering no longer leaks depth mask state into subsequent passes.
* Renderer pipeline is cleaner and easier to extend.

#### Next Steps

* Implement shader-side support for `AlphaMode::Mask` (alpha cutoff discard).
* Add material import logic to set `alpha_mode` automatically from texture metadata.
* Consider batching transparent objects by material once sorting is stable.
